### PR TITLE
Make eslint-config-signavio-test independent from eslint-config-signavio

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 module.exports = {
-  extends: require.resolve('eslint-config-signavio'),
   rules: {
     'import/no-extraneous-dependencies': ['error', { devDependencies: true }],
     'no-unused-expressions': 'off',
@@ -9,10 +8,12 @@ module.exports = {
     'jest/no-identical-title': 'error',
   },
   plugins: [
+    'import',
     'jest',
   ],
   env: {
     mocha: true,
     'jest/globals': true,
+    jasmine: true,
   },
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "Jan-Felix Schwarz",
   "license": "MIT",
   "dependencies": {
-    "eslint-config-signavio": "^1.3.2",
+    "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jest": "^19.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
* eslint-config-signavio-test can now be used independently, not extending any other lint config
* Also added 'import' plugin & dependency because its rule is used.

## Rationale:
Our folder structure looks like this:
client
-- explorer
----- test
------- .eslintrc.js // extends `eslint-config-signavio-test`
-- .eslintrc.js // extends `eslint-config-signavio`

* We are overriding certain rules of `eslint-config-signavio` for all our client projects in the root `eslintrc.js`.
* To have these also overridden in the test folders, we need to have an independent subset or linting rules for our tests. Otherwise, with the existing 'extends'-mechanism, we would need to override all rules in every project test subfolder. This would lead to lots of unnecessary duplication. 